### PR TITLE
Remove lengthy set() initialization

### DIFF
--- a/blazar/monitor/__init__.py
+++ b/blazar/monitor/__init__.py
@@ -24,7 +24,7 @@ def load_monitors(plugins):
     monitors = []
 
     # Setup a notification monitor
-    notification_plugins = set([])
+    notification_plugins = set()
     for plugin in plugins.values():
         if plugin.monitor:
             if plugin.monitor.is_notification_enabled():
@@ -34,7 +34,7 @@ def load_monitors(plugins):
             notification_monitor.NotificationMonitor(notification_plugins))
 
     # Setup a polling monitor
-    polling_plugins = set([])
+    polling_plugins = set()
     for plugin in plugins.values():
         if plugin.monitor:
             if plugin.monitor.is_polling_enabled():

--- a/blazar/monitor/base.py
+++ b/blazar/monitor/base.py
@@ -50,7 +50,7 @@ class BaseMonitor(object):
             # reservations. Depends on the state-machine blueprint.
 
         # Update flags of related leases and reservations.
-        lease_ids = set([])
+        lease_ids = set()
         for reservation_id, flags in reservation_flags.items():
             db_api.reservation_update(reservation_id, flags)
             LOG.debug('Reservation %s was updated: %s',

--- a/blazar/plugins/instances/instance_plugin.py
+++ b/blazar/plugins/instances/instance_plugin.py
@@ -186,7 +186,7 @@ class VirtualInstancePlugin(base.BasePlugin, nova.NovaClientWrapper):
         kept_host_ids = old_host_ids & candidate_ids
         removed_host_ids = old_host_ids - candidate_ids
         extra_host_ids = candidate_ids - old_host_ids
-        added_host_ids = set([])
+        added_host_ids = set()
 
         if len(kept_host_ids) > values['amount']:
             extra = len(kept_host_ids) - values['amount']

--- a/blazar/tests/plugins/instances/test_instance_plugin.py
+++ b/blazar/tests/plugins/instances/test_instance_plugin.py
@@ -200,7 +200,7 @@ class TestVirtualInstancePlugin(tests.TestCase):
             'start_date': '2030-01-01 08:00',
             'end_date': '2030-01-01 12:00'
             }
-        expected = {'added': set(['host-2', 'host-3']), 'removed': set([])}
+        expected = {'added': set(['host-2', 'host-3']), 'removed': set()}
         ret = plugin.pickup_hosts('reservation-id1', values)
 
         self.assertEqual(expected, ret)
@@ -241,7 +241,7 @@ class TestVirtualInstancePlugin(tests.TestCase):
             'start_date': '2030-01-01 08:00',
             'end_date': '2030-01-01 12:00'
             }
-        expected = {'added': set(['host-1', 'host-2']), 'removed': set([])}
+        expected = {'added': set(['host-1', 'host-2']), 'removed': set()}
         ret = plugin.pickup_hosts('reservation-id1', values)
 
         self.assertEqual(expected, ret)
@@ -295,7 +295,7 @@ class TestVirtualInstancePlugin(tests.TestCase):
             'end_date': '2030-01-01 12:00'
             }
 
-        expected = {'added': set(['host-1', 'host-3']), 'removed': set([])}
+        expected = {'added': set(['host-1', 'host-3']), 'removed': set()}
         ret = plugin.pickup_hosts('reservation-id1', params)
 
         self.assertEqual(expected, ret)
@@ -564,7 +564,7 @@ class TestVirtualInstancePlugin(tests.TestCase):
         values = self.get_input_values(1, 1024, 10, 1, False,
                                        '2020-07-01 10:00', '2020-07-01 11:00',
                                        'lease-1')
-        expect = {'added': set([]),
+        expect = {'added': set(),
                   'removed': set(['host-id1', 'host-id2', 'host-id3'])}
         ret = plugin.pickup_hosts(reservation['id'], values)
         self.assertEqual(expect['added'], ret['added'])
@@ -590,7 +590,7 @@ class TestVirtualInstancePlugin(tests.TestCase):
         values = self.get_input_values(1, 1024, 10, 4, False,
                                        '2020-07-01 10:00', '2020-07-01 11:00',
                                        'lease-1')
-        expect = {'added': set(['host-id4']), 'removed': set([])}
+        expect = {'added': set(['host-id4']), 'removed': set()}
         ret = plugin.pickup_hosts(reservation['id'], values)
         self.assertEqual(expect['added'], ret['added'])
         self.assertEqual(expect['removed'], ret['removed'])


### PR DESCRIPTION
I think `set()` is more easily to be read than `set([])`.
Moreover, `set()` is more faster than current codes.

Here below is exam code.
```python
import time

def timeit(method):
    def timed(*args, **kw):
        ts = time.time()
        result = method(*args, **kw)
        te = time.time()
        print('%2.2f s' % (te - ts))
        return result
    return timed

@timeit
def previous_init():
    for i in range(10000000):
        s = set([])
        
@timeit
def new_init():
    for i in range(10000000):
        s = set()

previous_init() # took 2.0s
new_init() # took 1.2s
```